### PR TITLE
fix: set up persistent profile for inspector

### DIFF
--- a/src/inspector.py
+++ b/src/inspector.py
@@ -16,6 +16,8 @@ class BaseInspector(qt.QWidget):
         self.setAttribute(qt.Qt.WidgetAttribute.WA_DeleteOnClose)
         log_widget_destroyed(self)
         self.webview = qt.QWebEngineView(self)
+        profile = qt.QWebEngineProfile("inspector", self)
+        self.webview.setPage(qt.QWebEnginePage(profile, self.webview))
         log_widget_destroyed(self.webview)
         self.setup_layout()
 


### PR DESCRIPTION
devtools settings will be stored persistently across sessions in the `Anki2/QtWebEngine/inspector` folder.

fixes #28
