### PR TITLE
Add support for inspecting webviews in unknown windows

### DIFF
--- a/src/context_menu.py
+++ b/src/context_menu.py
@@ -7,7 +7,7 @@ from aqt.webview import AnkiWebView
 from . import consts
 from .inspector import MainWindowInspector, SubWindowInspector
 from .widgets import InspectorDock
-from .window_info import windows
+from .window_info import windows, WindowInfo
 
 
 def inspect_main_window(inspected_page: webview.AnkiWebPage) -> None:
@@ -44,27 +44,31 @@ def inspect_sub_window(
 
 def on_webview_will_show_context_menu(webview: AnkiWebView, menu: qt.QMenu) -> None:
     window = webview.window()
-    if window_info := next(
-        (i for i in windows if type(window) is i.get_widget()), None
-    ):
-        if window_info.main_window:
-            # mw.web, mw.bottomWeb, mw.toolbarWeb
-            menu.addAction(
-                consts.CONTEXT_MENU_ITEM_LABEL,
-                lambda: inspect_main_window(webview.page()),
-            )
+    # Falls back to default WindowInfo for unknown windows (e.g. add-ons)
+    window_info = next(
+        (i for i in windows if type(window) is i.widget_class), WindowInfo()
+    )
+
+    if window_info.main_window:
+        # mw.web, mw.bottomWeb, mw.toolbarWeb
+        menu.addAction(
+            consts.CONTEXT_MENU_ITEM_LABEL,
+            lambda: inspect_main_window(webview.page()),
+        )
+    else:
+        # clayout, previewer, stats, etc.
+        target: qt.QWidget
+        if callable(window_info.target):
+            target = window_info.target(window)
+        elif window_info.target:
+            target = getattr(window, window_info.target, webview)
         else:
-            # clayout, previewer, stats, etc.
-            target: qt.QWidget
-            if isinstance(window_info.target, str):
-                target = getattr(window, window_info.target, webview)
-            else:
-                target = window_info.target(window)
-            insert_pos = window_info.insert_pos
-            menu.addAction(
-                consts.CONTEXT_MENU_ITEM_LABEL,
-                lambda: inspect_sub_window(webview.page(), window, target, insert_pos),
-            )
+            target = webview
+        insert_pos = window_info.insert_pos
+        menu.addAction(
+            consts.CONTEXT_MENU_ITEM_LABEL,
+            lambda: inspect_sub_window(webview.page(), window, target, insert_pos),
+        )
 
 
 def on_editor_will_show_context_menu(

--- a/src/window_info.py
+++ b/src/window_info.py
@@ -12,12 +12,16 @@ from .logger import logger
 
 @dataclass
 class WindowInfo:
-    dotted_attr: str
+    dotted_attr: str | None = None
     target: Union[str, Callable[[qt.QWidget], qt.QWidget]] = ""
     insert_pos: int = 0
     main_window: bool = False
 
-    def get_widget(self) -> qt.Qwidget | None:
+    @property
+    def widget_class(self) -> type[qt.QWidget] | None:
+        if not self.dotted_attr:
+            return None
+
         try:
             return attrgetter(self.dotted_attr)(aqt)
         except Exception as e:


### PR DESCRIPTION
Make it possible to use the webview inspector for webviews in unknown windows (add-on windows).
(The PR has the same purpose as https://github.com/hikaru-y/anki21-addon-ankiwebview-inspector/pull/24.)

## Proposed changes
- Fall back to default `WindowInfo` for unknown windows
- Make `WindowInfo.dotted_attr` optional (default `None`)
- Rename `get_widget()` to `widget_class` property
- Fix typo in type hint (`Qwidget` → `QWidget`)
- Handle target resolution explicitly: callable → call it, string → getattr, empty → fallback to webview

